### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 	},
   "require": {
     "ext-json": "*",
-	  "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|5.8.x",
-	  "illuminate/pipeline": "~5.5.0|~5.6.0|~5.7.0|5.8.x",
-	  "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|5.8.x"
+	  "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+	  "illuminate/pipeline": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+	  "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
   }
 }


### PR DESCRIPTION
Update the Illuminate component dependencies to allow installation in Laravel 6 apps.