### PR TITLE
Allow consumer apps to override ActionEvent

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,7 +6,7 @@ if (!function_exists('action_event')) {
 
     function action_event($subject, $action_name)
     {
-        $event = new ActionEvent();
+        $event = app(ActionEvent::class);
         $event->setSubject($subject);
 
         // hacky


### PR DESCRIPTION
Resolve the ActionEvent class out of Laravel's container rather than instantiating it directly, so consumer apps can override it as needed (e.g. to customize the table).